### PR TITLE
feat: add optional PowerMem CLI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.pnpm-store/
 dist/
 *.log
 .env

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Use global pnpm store (home dir) instead of project-local .pnpm-store.
+# Remove this file if you prefer the default or another store-dir.
+store-dir=~/.pnpm-store

--- a/README.md
+++ b/README.md
@@ -162,10 +162,23 @@ Edit OpenClaw’s config (e.g. `~/.openclaw/openclaw.json). Add or merge `plugin
 }
 ```
 
+**CLI mode (no server):** To use the PowerMem CLI instead of the HTTP server (same machine, no `powermem-server`), set `"mode": "cli"` and optionally `envFile` / `pmemPath`:
+
+```json
+"config": {
+  "mode": "cli",
+  "envFile": "/path/to/powermem/.env",
+  "pmemPath": "pmem",
+  "autoCapture": true,
+  "autoRecall": true,
+  "inferOnAdd": true
+}
+```
+
 Notes:
 
-- `baseUrl`: PowerMem HTTP base URL **without** `/api/v1`, e.g. `http://localhost:8000` or your host/port.
-- If PowerMem has API key auth, add `"apiKey": "your-key"` under `config`.
+- **HTTP (default):** `baseUrl` is required; PowerMem HTTP base URL **without** `/api/v1`, e.g. `http://localhost:8000`. If PowerMem has API key auth, add `"apiKey": "your-key"`.
+- **CLI:** Set `mode` to `"cli"`. Optional: `envFile` (path to PowerMem `.env`), `pmemPath` (default `pmem`). Requires `pmem` on PATH and a valid PowerMem config (e.g. `.env`).
 - **Restart the OpenClaw gateway** (or Mac menubar app) after changing config.
 
 ---
@@ -199,8 +212,11 @@ If search returns the line you added (or similar), the full flow (PowerMem → p
 
 | Option        | Required | Description |
 |---------------|----------|-------------|
-| `baseUrl`     | Yes      | PowerMem API base URL, e.g. `http://localhost:8000`, no `/api/v1` suffix. |
-| `apiKey`      | No       | Set when PowerMem server has API key authentication enabled. |
+| `mode`        | No       | Backend: `"http"` (default) or `"cli"`. Use `cli` to run `pmem` locally without a server. |
+| `baseUrl`     | Yes (http) | PowerMem API base URL when `mode` is `http`, e.g. `http://localhost:8000`, no `/api/v1` suffix. |
+| `apiKey`      | No       | Set when PowerMem server has API key authentication enabled (http mode). |
+| `envFile`     | No       | CLI mode: path to PowerMem `.env` file. Optional; pmem discovers if omitted. |
+| `pmemPath`    | No       | CLI mode: path to `pmem` executable; default `pmem`. |
 | `userId`      | No       | PowerMem `user_id` for isolation; default `openclaw-user`. |
 | `agentId`     | No       | PowerMem `agent_id` for isolation; default `openclaw-agent`. |
 | `autoCapture` | No       | Auto-store from conversations after agent ends; default `true`. |

--- a/README_CN.md
+++ b/README_CN.md
@@ -162,10 +162,23 @@ openclaw plugins install -l /path/to/openclaw-extension-powermem
 }
 ```
 
+**CLI 模式（无需起服务）：** 若希望用 PowerMem CLI 而不是 HTTP 服务（本机、不跑 powermem-server），可设置 `"mode": "cli"`，并可选填 `envFile` / `pmemPath`：
+
+```json
+"config": {
+  "mode": "cli",
+  "envFile": "/path/to/powermem/.env",
+  "pmemPath": "pmem",
+  "autoCapture": true,
+  "autoRecall": true,
+  "inferOnAdd": true
+}
+```
+
 说明：
 
-- `baseUrl`：PowerMem 的 HTTP 地址，**不要**加 `/api/v1`，就写 `http://localhost:8000` 或你的实际主机/端口。
-- 若 PowerMem 开了 API Key 鉴权，在 `config` 里增加 `"apiKey": "你的key"`。
+- **HTTP（默认）：** 需填写 `baseUrl`，PowerMem 的 HTTP 地址，**不要**加 `/api/v1`。若 PowerMem 开了 API Key 鉴权，在 `config` 里增加 `"apiKey": "你的key"`。
+- **CLI：** 将 `mode` 设为 `"cli"`。可选：`envFile`（PowerMem 的 `.env` 路径）、`pmemPath`（默认 `pmem`）。需本机已安装 `pmem` 且配置好 PowerMem（如 `.env`）。
 - 改完配置后**重启 OpenClaw gateway**（或重启 Mac 菜单栏应用），配置才会生效。
 
 ---
@@ -199,8 +212,11 @@ openclaw ltm search "咖啡"
 
 | 选项          | 必填 | 说明 |
 |---------------|------|------|
-| `baseUrl`     | 是   | PowerMem API 根地址，如 `http://localhost:8000`，不要带 `/api/v1`。 |
-| `apiKey`      | 否   | PowerMem 开启 API Key 鉴权时填写。 |
+| `mode`        | 否   | 后端：`"http"`（默认）或 `"cli"`。选 `cli` 时本机直接跑 `pmem`，无需起服务。 |
+| `baseUrl`     | 是（http） | `mode` 为 `http` 时必填，PowerMem API 根地址，如 `http://localhost:8000`，不要带 `/api/v1`。 |
+| `apiKey`      | 否   | PowerMem 开启 API Key 鉴权时填写（http 模式）。 |
+| `envFile`     | 否   | CLI 模式：PowerMem `.env` 文件路径；不填则 pmem 自动发现。 |
+| `pmemPath`    | 否   | CLI 模式：`pmem` 可执行路径，默认 `pmem`。 |
 | `userId`      | 否   | 用于多用户隔离，默认 `openclaw-user`。 |
 | `agentId`     | 否   | 用于多 Agent 隔离，默认 `openclaw-agent`。 |
 | `autoCapture` | 否   | 会话结束后是否自动把对话交给 PowerMem 抽取记忆，默认 `true`。 |

--- a/client-cli.ts
+++ b/client-cli.ts
@@ -1,0 +1,183 @@
+/**
+ * PowerMem CLI backend.
+ * Spawns `pmem` (or pmemPath) with -j and parses JSON stdout.
+ * Use when mode is "cli" (no HTTP server required).
+ */
+
+import { execFileSync } from "node:child_process";
+import type { PowerMemConfig } from "./config.js";
+import type { PowerMemAddResult, PowerMemSearchResult } from "./client.js";
+
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024; // 10 MiB
+
+export type PowerMemCLIClientOptions = {
+  pmemPath: string;
+  envFile?: string;
+  userId: string;
+  agentId: string;
+};
+
+function parseJsonOrThrow<T>(stdout: string, context: string): T {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error(`${context}: empty output`);
+  }
+  try {
+    return JSON.parse(trimmed) as T;
+  } catch (err) {
+    throw new Error(`${context}: invalid JSON - ${String(err)}`);
+  }
+}
+
+/** Normalize CLI add result to PowerMemAddResult[]. */
+function normalizeAddOutput(raw: unknown): PowerMemAddResult[] {
+  if (Array.isArray(raw)) {
+    return raw.map((r) => ({
+      memory_id: Number((r as Record<string, unknown>).id ?? (r as Record<string, unknown>).memory_id ?? 0),
+      content: String((r as Record<string, unknown>).memory ?? (r as Record<string, unknown>).content ?? ""),
+      user_id: (r as Record<string, unknown>).user_id as string | undefined,
+      agent_id: (r as Record<string, unknown>).agent_id as string | undefined,
+      metadata: (r as Record<string, unknown>).metadata as Record<string, unknown> | undefined,
+    }));
+  }
+  const obj = raw as Record<string, unknown>;
+  const results = obj?.results ?? obj?.data;
+  if (Array.isArray(results)) {
+    return results.map((r: Record<string, unknown>) => ({
+      memory_id: Number(r.id ?? r.memory_id ?? 0),
+      content: String(r.memory ?? r.content ?? ""),
+      user_id: r.user_id as string | undefined,
+      agent_id: r.agent_id as string | undefined,
+      metadata: r.metadata as Record<string, unknown> | undefined,
+    }));
+  }
+  return [];
+}
+
+/** Normalize CLI search result to PowerMemSearchResult[]. */
+function normalizeSearchOutput(raw: unknown): PowerMemSearchResult[] {
+  if (Array.isArray(raw)) {
+    return raw.map((r) => ({
+      memory_id: Number((r as Record<string, unknown>).memory_id ?? (r as Record<string, unknown>).id ?? 0),
+      content: String((r as Record<string, unknown>).content ?? (r as Record<string, unknown>).memory ?? ""),
+      score: Number((r as Record<string, unknown>).score ?? (r as Record<string, unknown>).similarity ?? 0),
+      metadata: (r as Record<string, unknown>).metadata as Record<string, unknown> | undefined,
+    }));
+  }
+  const obj = raw as Record<string, unknown>;
+  const results = obj?.results ?? obj?.data ?? obj?.memories;
+  if (Array.isArray(results)) {
+    return results.map((r: Record<string, unknown>) => ({
+      memory_id: Number(r.memory_id ?? r.id ?? 0),
+      content: String(r.content ?? r.memory ?? ""),
+      score: Number(r.score ?? r.similarity ?? 0),
+      metadata: r.metadata as Record<string, unknown> | undefined,
+    }));
+  }
+  return [];
+}
+
+export class PowerMemCLIClient {
+  private readonly pmemPath: string;
+  private readonly envFile?: string;
+  private readonly userId: string;
+  private readonly agentId: string;
+
+  constructor(options: PowerMemCLIClientOptions) {
+    this.pmemPath = options.pmemPath;
+    this.envFile = options.envFile;
+    this.userId = options.userId;
+    this.agentId = options.agentId;
+  }
+
+  static fromConfig(cfg: PowerMemConfig, userId: string, agentId: string): PowerMemCLIClient {
+    return new PowerMemCLIClient({
+      pmemPath: cfg.pmemPath ?? "pmem",
+      envFile: cfg.envFile,
+      userId,
+      agentId,
+    });
+  }
+
+  private run(args: string[], context: string): string {
+    try {
+      const out = execFileSync(this.pmemPath, args, {
+        encoding: "utf-8",
+        maxBuffer: DEFAULT_MAX_BUFFER,
+        env: this.envFile ? { ...process.env, POWERMEM_ENV_FILE: this.envFile } : process.env,
+      });
+      return out;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const stderr = err && typeof err === "object" && "stderr" in err ? String((err as { stderr: unknown }).stderr) : "";
+      throw new Error(`${context}: ${msg}${stderr ? ` ${stderr}` : ""}`);
+    }
+  }
+
+  async health(): Promise<{ status: string }> {
+    const argsList = [
+      ...(this.envFile ? ["--env-file", this.envFile] : []),
+      "--json", "-j",
+      "memory", "list",
+      "--user-id", this.userId,
+      "--agent-id", this.agentId,
+      "--limit", "1",
+    ];
+    try {
+      this.run(argsList, "health");
+      return { status: "healthy" };
+    } catch {
+      return { status: "unhealthy" };
+    }
+  }
+
+  async add(
+    content: string,
+    options: { infer?: boolean; metadata?: Record<string, unknown> } = {},
+  ): Promise<PowerMemAddResult[]> {
+    const args = [
+      ...(this.envFile ? ["--env-file", this.envFile] : []),
+      "--json", "-j",
+      "memory", "add",
+      content,
+      "--user-id", this.userId,
+      "--agent-id", this.agentId,
+    ];
+    if (options.infer === false) {
+      args.push("--no-infer");
+    }
+    if (options.metadata && Object.keys(options.metadata).length > 0) {
+      args.push("--metadata", JSON.stringify(options.metadata));
+    }
+    const stdout = this.run(args, "add");
+    const raw = parseJsonOrThrow<unknown>(stdout, "add");
+    return normalizeAddOutput(raw);
+  }
+
+  async search(query: string, limit = 5): Promise<PowerMemSearchResult[]> {
+    const args = [
+      ...(this.envFile ? ["--env-file", this.envFile] : []),
+      "--json", "-j",
+      "memory", "search",
+      query,
+      "--user-id", this.userId,
+      "--agent-id", this.agentId,
+      "--limit", String(limit),
+    ];
+    const stdout = this.run(args, "search");
+    const raw = parseJsonOrThrow<unknown>(stdout, "search");
+    return normalizeSearchOutput(raw);
+  }
+
+  async delete(memoryId: number | string): Promise<void> {
+    const id = String(memoryId);
+    const args = [
+      ...(this.envFile ? ["--env-file", this.envFile] : []),
+      "memory", "delete", id,
+      "--user-id", this.userId,
+      "--agent-id", this.agentId,
+      "--yes",
+    ];
+    this.run(args, "delete");
+  }
+}

--- a/config.ts
+++ b/config.ts
@@ -23,9 +23,16 @@ function resolveEnvVars(value: string): string {
   });
 }
 
+export type PowerMemMode = "http" | "cli";
+
 export type PowerMemConfig = {
+  mode: PowerMemMode;
   baseUrl: string;
   apiKey?: string;
+  /** CLI mode: path to .env (optional; pmem discovers if omitted). */
+  envFile?: string;
+  /** CLI mode: path to pmem binary (default "pmem"). */
+  pmemPath?: string;
   userId?: string;
   agentId?: string;
   autoCapture: boolean;
@@ -34,8 +41,11 @@ export type PowerMemConfig = {
 };
 
 const ALLOWED_KEYS = [
+  "mode",
   "baseUrl",
   "apiKey",
+  "envFile",
+  "pmemPath",
   "userId",
   "agentId",
   "autoCapture",
@@ -51,21 +61,42 @@ export const powerMemConfigSchema = {
     const cfg = value as Record<string, unknown>;
     assertAllowedKeys(cfg, [...ALLOWED_KEYS], "memory-powermem config");
 
-    const baseUrlRaw = cfg.baseUrl;
-    if (typeof baseUrlRaw !== "string" || !baseUrlRaw.trim()) {
-      throw new Error("memory-powermem baseUrl is required");
-    }
-    const baseUrl = resolveEnvVars(baseUrlRaw.trim()).replace(/\/+$/, "");
+    const mode =
+      (cfg.mode === "cli" || cfg.mode === "http" ? cfg.mode : undefined) ?? "http";
 
-    const apiKeyRaw = cfg.apiKey;
-    const apiKey =
-      typeof apiKeyRaw === "string" && apiKeyRaw.trim()
-        ? resolveEnvVars(apiKeyRaw.trim())
+    let baseUrl = "";
+    let apiKey: string | undefined;
+    if (mode === "http") {
+      const baseUrlRaw = cfg.baseUrl;
+      if (typeof baseUrlRaw !== "string" || !baseUrlRaw.trim()) {
+        throw new Error("memory-powermem baseUrl is required when mode is http");
+      }
+      baseUrl = resolveEnvVars(baseUrlRaw.trim()).replace(/\/+$/, "");
+      const apiKeyRaw = cfg.apiKey;
+      apiKey =
+        typeof apiKeyRaw === "string" && apiKeyRaw.trim()
+          ? resolveEnvVars(apiKeyRaw.trim())
+          : undefined;
+    }
+
+    const envFileRaw = cfg.envFile;
+    const envFile =
+      typeof envFileRaw === "string" && envFileRaw.trim()
+        ? envFileRaw.trim()
         : undefined;
 
+    const pmemPathRaw = cfg.pmemPath;
+    const pmemPath =
+      typeof pmemPathRaw === "string" && pmemPathRaw.trim()
+        ? pmemPathRaw.trim()
+        : "pmem";
+
     return {
+      mode,
       baseUrl,
       apiKey,
+      envFile,
+      pmemPath,
       userId:
         typeof cfg.userId === "string" && cfg.userId.trim()
           ? cfg.userId.trim()

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,10 @@
 /**
  * OpenClaw Memory (PowerMem) Plugin
  *
- * Long-term memory via PowerMem HTTP API: intelligent extraction,
- * Ebbinghaus forgetting curve, multi-agent isolation. Requires a running
- * PowerMem server (e.g. powermem-server --port 8000).
+ * Long-term memory via PowerMem: intelligent extraction, Ebbinghaus
+ * forgetting curve, multi-agent isolation. Supports two backends:
+ * - HTTP: requires a running PowerMem server (e.g. powermem-server --port 8000).
+ * - CLI: runs pmem locally (no server); set mode to "cli" and optionally envFile/pmemPath.
  */
 
 import { Type } from "@sinclair/typebox";
@@ -16,6 +17,7 @@ import {
   type PowerMemConfig,
 } from "./config.js";
 import { PowerMemClient } from "./client.js";
+import { PowerMemCLIClient } from "./client-cli.js";
 
 // ============================================================================
 // Plugin Definition
@@ -25,7 +27,7 @@ const memoryPlugin = {
   id: "memory-powermem",
   name: "Memory (PowerMem)",
   description:
-    "PowerMem-backed long-term memory (intelligent extraction, forgetting curve). Requires PowerMem server.",
+    "PowerMem-backed long-term memory (intelligent extraction, forgetting curve). Backend: HTTP server or local CLI (pmem).",
   kind: "memory" as const,
   configSchema: powerMemConfigSchema,
 
@@ -33,10 +35,14 @@ const memoryPlugin = {
     const cfg = powerMemConfigSchema.parse(api.pluginConfig) as PowerMemConfig;
     const userId = resolveUserId(cfg);
     const agentId = resolveAgentId(cfg);
-    const client = PowerMemClient.fromConfig(cfg, userId, agentId);
+    const client =
+      cfg.mode === "cli"
+        ? PowerMemCLIClient.fromConfig(cfg, userId, agentId)
+        : PowerMemClient.fromConfig(cfg, userId, agentId);
+    const modeLabel = cfg.mode === "cli" ? `cli (${cfg.pmemPath ?? "pmem"})` : cfg.baseUrl;
 
     api.logger.info(
-      `memory-powermem: plugin registered (baseUrl: ${cfg.baseUrl}, user: ${userId}, agent: ${agentId})`,
+      `memory-powermem: plugin registered (mode: ${cfg.mode}, ${modeLabel}, user: ${userId}, agent: ${agentId})`,
     );
 
     // ========================================================================
@@ -407,12 +413,17 @@ const memoryPlugin = {
       start: async (_ctx) => {
         try {
           const h = await client.health();
+          const where = cfg.mode === "cli" ? `cli ${cfg.pmemPath ?? "pmem"}` : cfg.baseUrl;
           api.logger.info(
-            `memory-powermem: initialized (${cfg.baseUrl}, health: ${h.status})`,
+            `memory-powermem: initialized (${where}, health: ${h.status})`,
           );
         } catch (err) {
+          const hint =
+            cfg.mode === "cli"
+              ? "is pmem on PATH and POWERMEM_ENV_FILE or --env-file set?"
+              : "is PowerMem server running?";
           api.logger.warn(
-            `memory-powermem: health check failed (is PowerMem server running?): ${String(err)}`,
+            `memory-powermem: health check failed (${hint}): ${String(err)}`,
           );
         }
       },

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,16 +2,33 @@
   "id": "memory-powermem",
   "kind": "memory",
   "uiHints": {
+    "mode": {
+      "label": "Backend mode",
+      "placeholder": "http",
+      "help": "Use \"http\" to talk to powermem-server, or \"cli\" to run pmem locally (no server). Default: http"
+    },
     "baseUrl": {
       "label": "PowerMem API URL",
       "placeholder": "http://localhost:8000",
-      "help": "Base URL of PowerMem HTTP API (no /api/v1). Start server with: powermem-server --port 8000"
+      "help": "Required when mode is http. Base URL of PowerMem HTTP API (no /api/v1). Start server with: powermem-server --port 8000"
     },
     "apiKey": {
       "label": "API Key",
       "sensitive": true,
       "placeholder": "",
-      "help": "Optional; required if PowerMem server has authentication enabled"
+      "help": "Optional; required if PowerMem server has authentication enabled (http mode only)"
+    },
+    "envFile": {
+      "label": "Env file path",
+      "placeholder": "",
+      "advanced": true,
+      "help": "CLI mode: path to PowerMem .env file. Optional; pmem discovers .env if omitted"
+    },
+    "pmemPath": {
+      "label": "pmem binary path",
+      "placeholder": "pmem",
+      "advanced": true,
+      "help": "CLI mode: path to pmem (or powermem) executable. Default: pmem"
     },
     "userId": {
       "label": "User ID",
@@ -42,14 +59,17 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "mode": { "type": "string", "enum": ["http", "cli"] },
       "baseUrl": { "type": "string" },
       "apiKey": { "type": "string" },
+      "envFile": { "type": "string" },
+      "pmemPath": { "type": "string" },
       "userId": { "type": "string" },
       "agentId": { "type": "string" },
       "autoCapture": { "type": "boolean" },
       "autoRecall": { "type": "boolean" },
       "inferOnAdd": { "type": "boolean" }
     },
-    "required": ["baseUrl"]
+    "required": []
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openclaw-extension-powermem",
   "version": "1.0.0",
-  "description": "OpenClaw plugin: long-term memory via PowerMem HTTP API (intelligent extraction, Ebbinghaus forgetting curve).",
+  "description": "OpenClaw plugin: long-term memory via PowerMem (HTTP or local CLI; intelligent extraction, Ebbinghaus forgetting curve).",
   "type": "module",
   "main": "index.ts",
   "exports": {
@@ -11,6 +11,7 @@
     "index.ts",
     "config.ts",
     "client.ts",
+    "client-cli.ts",
     "openclaw.plugin.json"
   ],
   "scripts": {
@@ -21,6 +22,7 @@
     "@sinclair/typebox": "^0.34.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.0.0",
     "vitest": "^2.0.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["vitest/globals"]
+    "types": ["node", "vitest/globals"]
   },
   "include": ["*.ts", "*.test.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
feat: add optional PowerMem CLI backend and repo hygiene

- Add client-cli.ts (PowerMemCLIClient) for local pmem usage without HTTP server
- Extend config with mode (http|cli), envFile, pmemPath; update plugin manifest
- Wire CLI/HTTP backend selection in index.ts based on config.mode
- Add .npmrc (store-dir=~/.pnpm-store) and .gitignore (.pnpm-store/, etc.)
- Update README/README_CN with CLI mode example and config table
- Adjust package.json files, tsconfig types (node), and devDeps (@types/node)