### PR TITLE
docs: add TweetClaw memory workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,27 @@ If search returns what you just added (or similar content), the full flow (insta
 
 ---
 
+## Example: remember X/Twitter research
+
+PowerMem works well with source-specific OpenClaw plugins that gather fast-moving external signals. For X/Twitter workflows, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw), use it to search tweets and replies, look up users, export followers, monitor tweets, or run giveaway draws, then store only the summarized findings and follow-up decisions in PowerMem.
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+```
+
+Example prompt:
+
+```text
+Search recent tweets and replies about "openclaw memory plugin" with TweetClaw.
+Summarize recurring requests and use memory_store to remember the product signals,
+source query, date, and next action.
+```
+
+Keep credentials in local OpenClaw config; do not paste API keys, signing keys, raw cookies, or full scraped timelines into memory. Store concise summaries, links, tweet IDs, and follow-up decisions so future agents can recall the context without rereading the feed.
+
+---
+
 ## OpenClaw plugin commands (reference)
 
 Common CLI commands for managing plugins:

--- a/README_CN.md
+++ b/README_CN.md
@@ -266,6 +266,26 @@ openclaw ltm search "咖啡"
 
 ---
 
+## 示例：记住 X/Twitter 研究结果
+
+PowerMem 适合和负责采集外部信号的 OpenClaw 插件一起使用。X/Twitter 场景可安装 [TweetClaw](https://github.com/Xquik-dev/tweetclaw)，用它搜索推文和回复、查询用户、导出关注者、监控推文或执行抽奖，然后只把摘要结论和后续决策写入 PowerMem。
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+```
+
+示例提示词：
+
+```text
+请用 TweetClaw 搜索最近关于 "openclaw memory plugin" 的推文和回复。
+总结反复出现的需求，并用 memory_store 记住产品信号、来源查询、日期和下一步行动。
+```
+
+把凭据留在本地 OpenClaw 配置里；不要把 API Key、签名密钥、原始 cookie 或完整抓取时间线粘贴进记忆。只保存简短摘要、链接、tweet ID 和后续决策，方便后续 Agent 召回上下文而无需重新读取 feed。
+
+---
+
 ## OpenClaw 插件常用命令（参考）
 
 管理插件时常用的 CLI 命令：


### PR DESCRIPTION
## Summary
- Add README and README_CN examples for using TweetClaw as an X/Twitter signal source with PowerMem.
- Document storing summaries, links, tweet IDs, and follow-up decisions instead of raw timelines or credentials.

## Validation
- git diff --check
- Docs-only change; package tests were not run.