### PR TITLE
fix: declare PowerMem agent tools in manifest

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -300,5 +300,19 @@
       "useOpenClawModel": { "type": "boolean" }
     },
     "required": []
+  },
+  "contracts": {
+    "tools": [
+      "memory_recall",
+      "memory_store",
+      "memory_forget",
+      "experience_store",
+      "experience_recall",
+      "agent_memory_add",
+      "agent_memory_list",
+      "agent_memory_share",
+      "agent_memory_shared",
+      "cross_scope_share"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Declare the PowerMem plugin's agent tools in `openclaw.plugin.json`.

OpenClaw 2026.5.2+ uses openclaw.plugin.json contracts.tools for plugin tool ownership discovery. Without these declarations, runtime-registered tools such as memory_recall and memory_store may not be discoverable or may trigger plugin contract diagnostics in newer OpenClaw versions.

## Solution Description

Added a `contracts.tools` section to `openclaw.plugin.json` and listed all tools registered by the plugin:

- `memory_recall`
- `memory_store`
- `memory_forget`
- `experience_store`
- `experience_recall`
- `agent_memory_add`
- `agent_memory_list`
- `agent_memory_share`
- `agent_memory_shared`
- `cross_scope_share`

Validation performed:

- Parsed `openclaw.plugin.json` successfully
- Compared declared tool names with `api.registerTool` names in `src/index.ts`
- Ran `npm run lint`